### PR TITLE
A few small improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         }
     ],
     "require": {
+        "php": "^7.2",
         "illuminate/support": "~7.0",
         "doctrine/dbal": ">=2.10",
         "composer/composer": "^1.10",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,9 @@
     ],
     "require": {
         "php": "^7.2",
-        "illuminate/support": "~7.0",
+        "ext-json": "*",
+        "illuminate/contracts": "^7.0",
+        "illuminate/support": "^7.0",
         "doctrine/dbal": ">=2.10",
         "composer/composer": "^1.10",
         "spatie/laravel-image-optimizer": "^1.6",
@@ -40,7 +42,10 @@
         "laravel": {
             "providers": [
                 "Voyager\\Admin\\VoyagerServiceProvider"
-            ]
+            ],
+            "aliases": {
+                "Voyager": "Voyager\\Admin\\Facades\\Voyager"
+            }
         }
     }
 }

--- a/src/Contracts/Plugins/GenericPlugin.php
+++ b/src/Contracts/Plugins/GenericPlugin.php
@@ -4,6 +4,13 @@ namespace Voyager\Admin\Contracts\Plugins;
 
 use Illuminate\View\View;
 
+/**
+ * @property-read string $name          The name of this voyager plugin.
+ * @property-read string $description   A short description of this plugins function.
+ * @property-read string $repository    The packagist package name for this plugin.
+ * @property-read string $website       The public URL to this plugins repository.
+ * @property-read string $version       The plugins current package version.
+ */
 interface GenericPlugin
 {
     public function registerProtectedRoutes();

--- a/src/Manager/Plugins.php
+++ b/src/Manager/Plugins.php
@@ -75,7 +75,7 @@ class Plugins
     public function launchPlugins()
     {
         $this->getAllPlugins()->each(function ($plugin) {
-            if ($plugin->enabled || $plugin->type == 'theme') {
+            if ($plugin->enabled || $plugin->type === 'theme') {
                 $plugin->registerPublicRoutes();
                 if (method_exists($plugin, 'registerMenuItems')) {
                     $plugin->registerMenuItems($this->menumanager);

--- a/src/Manager/Plugins.php
+++ b/src/Manager/Plugins.php
@@ -98,7 +98,7 @@ class Plugins
         $plugin = $this->getPluginsByType($type)->where('enabled')->first();
         if (!$plugin && $fallback !== null) {
             $plugin = $fallback;
-            if (!($fallback instanceof IsGenericPlugin)) {
+            if (!($fallback instanceof GenericPlugin)) {
                 $plugin = new $fallback();
             }
         }

--- a/src/Manager/Plugins.php
+++ b/src/Manager/Plugins.php
@@ -46,7 +46,7 @@ class Plugins
             $plugin->type = $this->getPluginType($plugin);
 
             $plugin->identifier = $plugin->repository.'@'.class_basename($plugin);
-            $plugin->enabled = in_array($plugin->identifier, $this->enabled_plugins);
+            $plugin->enabled = in_array($plugin->identifier, $this->enabled_plugins, true);
             if ($plugin->getInstructionsView()) {
                 $plugin->instructions = $plugin->getInstructionsView()->render();
             }
@@ -113,14 +113,14 @@ class Plugins
 
     public function getAvailablePlugins()
     {
-        return VoyagerFacade::getJson(File::get(realpath(__DIR__.'/../../plugins.json')), []);
+        return VoyagerFacade::getJson(File::get(dirname(__DIR__, 2) . '/plugins.json'), []);
     }
 
     protected function getPluginType($class)
     {
-        return collect(class_implements($class))->filter(function ($interface) {
+        return collect(class_implements($class))->filter(static function ($interface) {
             return Str::startsWith($interface, 'Voyager\\Admin\\Contracts\\Plugins\\');
-        })->transform(function ($interface) {
+        })->transform(static function ($interface) {
             return strtolower(str_replace(['Voyager\\Admin\\Contracts\\Plugins\\', 'Plugin'], '', $interface));
         })->first();
     }


### PR DESCRIPTION
This PR does a few things to improve some stuff overall:

- Adds property docblocks to `GenericPlugin` for required properties.
- Add PHP 7.2 requirement to package to mirror that of the `illuminate/support` package. (Otherwise at minimum it should be 7.1 due to usage of other PHP features)
- Small refactors in Plugins Manager class for stricter comparisons and fix undefined `IsGenericPlugin ` type.
- Defines functions as `static` where appropriate.