### PR TITLE
update formfield plugin interface for correct interface namespace

### DIFF
--- a/src/Contracts/Plugins/FormfieldPlugin.php
+++ b/src/Contracts/Plugins/FormfieldPlugin.php
@@ -2,7 +2,7 @@
 
 namespace Voyager\Admin\Contracts\Plugins;
 
-use Voyager\Admin\Classes\Formfield;
+use Voyager\Admin\Contracts\Formfields\Formfield;
 use Voyager\Admin\Contracts\Plugins\Features\Provider\JS;
 
 interface FormfieldPlugin extends GenericPlugin, JS


### PR DESCRIPTION
Seems that the interface namespace was moved a bit, so this accounts for that.