### PR TITLE
Implement V2 analog for modelClass

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5843,20 +5843,20 @@
         },
         {
             "name": "orchestra/testbench",
-            "version": "v6.7.0",
+            "version": "v6.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench.git",
-                "reference": "b009a5632f8b9c8455fb399486a367d1ed249c09"
+                "reference": "7713cc13587e08bace7359abee69f76e6017a561"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench/zipball/b009a5632f8b9c8455fb399486a367d1ed249c09",
-                "reference": "b009a5632f8b9c8455fb399486a367d1ed249c09",
+                "url": "https://api.github.com/repos/orchestral/testbench/zipball/7713cc13587e08bace7359abee69f76e6017a561",
+                "reference": "7713cc13587e08bace7359abee69f76e6017a561",
                 "shasum": ""
             },
             "require": {
-                "laravel/framework": "^8.0",
+                "laravel/framework": "^8.18.1",
                 "mockery/mockery": "^1.3.2",
                 "orchestra/testbench-core": "^6.9.1",
                 "php": ">=7.3 || >=8.0",
@@ -5891,7 +5891,7 @@
             ],
             "support": {
                 "issues": "https://github.com/orchestral/testbench/issues",
-                "source": "https://github.com/orchestral/testbench/tree/v6.7.0"
+                "source": "https://github.com/orchestral/testbench/tree/v6.7.1"
             },
             "funding": [
                 {
@@ -5903,7 +5903,7 @@
                     "type": "liberapay"
                 }
             ],
-            "time": "2020-12-15T03:38:46+00:00"
+            "time": "2020-12-28T14:56:36+00:00"
         },
         {
             "name": "orchestra/testbench-core",

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -27,7 +27,7 @@ createVoyager({
     locales: ["{!! implode('","', Voyager::getLocales()) !!}"],
     locale: '{{ Voyager::getLocale() }}',
     initial_locale: '{{ Voyager::getLocale() }}',
-    breads: {!! json_encode(resolve(\Voyager\Admin\Manager\Breads::class)->getBreads()) !!},
+    breads: {!! json_encode(resolve(\Voyager\Admin\Manager\Breads::class)->getBreadsForJson()) !!},
     formfields: {!! json_encode(resolve(\Voyager\Admin\Manager\Breads::class)->getFormfields()) !!},
     debug: {{ var_export(config('app.debug') ?? false, true) }},
     jsonOutput: {{ var_export(Voyager::setting('admin.json-output', true)) }},

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -27,7 +27,7 @@ createVoyager({
     locales: ["{!! implode('","', Voyager::getLocales()) !!}"],
     locale: '{{ Voyager::getLocale() }}',
     initial_locale: '{{ Voyager::getLocale() }}',
-    breads: {!! json_encode(resolve(\Voyager\Admin\Manager\Breads::class)->getBreadsForJson()) !!},
+    breads: {!! json_encode(resolve(\Voyager\Admin\Manager\Breads::class)->getBreads()->values()) !!},
     formfields: {!! json_encode(resolve(\Voyager\Admin\Manager\Breads::class)->getFormfields()) !!},
     debug: {{ var_export(config('app.debug') ?? false, true) }},
     jsonOutput: {{ var_export(Voyager::setting('admin.json-output', true)) }},

--- a/src/Http/Controllers/BreadBuilderController.php
+++ b/src/Http/Controllers/BreadBuilderController.php
@@ -217,7 +217,7 @@ class BreadBuilderController extends Controller
     {
         $this->authorize('browse breads');
         return response()->json([
-            'breads'  => $this->breadmanager->getBreads(),
+            'breads'  => $this->breadmanager->getBreadsForJson(),
             'backups' => $this->breadmanager->getBackups(),
         ], 200);
     }

--- a/src/Http/Controllers/BreadBuilderController.php
+++ b/src/Http/Controllers/BreadBuilderController.php
@@ -217,7 +217,7 @@ class BreadBuilderController extends Controller
     {
         $this->authorize('browse breads');
         return response()->json([
-            'breads'  => $this->breadmanager->getBreadsForJson(),
+            'breads'  => $this->breadmanager->getBreads()->values(),
             'backups' => $this->breadmanager->getBackups(),
         ], 200);
     }

--- a/src/Manager/Breads.php
+++ b/src/Manager/Breads.php
@@ -55,7 +55,7 @@ class Breads
     /**
      * Get all BREADs from storage and validate.
      *
-     * @return \Voyager\Admin\Classes\Bread
+     * @return \Illuminate\Support\Collection<string, BreadClass>
      */
     public function getBreads()
     {

--- a/src/Manager/Breads.php
+++ b/src/Manager/Breads.php
@@ -141,9 +141,21 @@ class Breads
      *
      * @return \Voyager\Admin\Classes\Bread
      */
-    public function getBread($table)
+    public function getBread(string $table)
     {
         return $this->getBreads()->where('table', $table)->first();
+    }
+
+    /**
+     * Get a BREAD by the table name.
+     *
+     * @param string $breadName
+     *
+     * @return \Voyager\Admin\Classes\Bread
+     */
+    public function getBreadByName(string $breadName)
+    {
+        return $this->getBreads()->get($breadName);
     }
 
     /**

--- a/src/Manager/Breads.php
+++ b/src/Manager/Breads.php
@@ -96,14 +96,6 @@ class Breads
     }
 
     /**
-     * @return Collection
-     */
-    public function getBreadsForJson()
-    {
-        return $this->getBreads()->values();
-    }
-
-    /**
      * Get backed-up BREADs.
      *
      * @return array

--- a/src/Manager/Breads.php
+++ b/src/Manager/Breads.php
@@ -87,7 +87,9 @@ class Breads
                 return $b;
             })->filter(function ($bread) {
                 return $bread !== null;
-            })->values();
+            })->values()->mapWithKeys(static function ($value, $key) {
+                return [$value->name_singular => $value];
+            });
         }
 
         return $this->breads;

--- a/src/Manager/Breads.php
+++ b/src/Manager/Breads.php
@@ -95,6 +95,9 @@ class Breads
         return $this->breads;
     }
 
+    /**
+     * @return Collection
+     */
     public function getBreadsForJson()
     {
         return $this->getBreads()->values();
@@ -146,7 +149,7 @@ class Breads
      *
      * @return \Voyager\Admin\Classes\Bread
      */
-    public function getBread(string $table)
+    public function getBread($table)
     {
         return $this->getBreads()->where('table', $table)->first();
     }
@@ -158,7 +161,7 @@ class Breads
      *
      * @return \Voyager\Admin\Classes\Bread
      */
-    public function getBreadByName(string $breadName)
+    public function getBreadByName($breadName)
     {
         return $this->getBreads()->get($breadName);
     }

--- a/src/Manager/Breads.php
+++ b/src/Manager/Breads.php
@@ -95,6 +95,11 @@ class Breads
         return $this->breads;
     }
 
+    public function getBreadsForJson()
+    {
+        return $this->getBreads()->values();
+    }
+
     /**
      * Get backed-up BREADs.
      *

--- a/src/Voyager.php
+++ b/src/Voyager.php
@@ -507,7 +507,12 @@ class Voyager
         });
     }
 
-    public function getBreadByName(string $breadName)
+    /**
+     * @param string $breadName
+     *
+     * @return Classes\Bread
+     */
+    public function getBreadByName($breadName)
     {
         return $this->breadmanager->getBreadByName($breadName);
     }

--- a/src/Voyager.php
+++ b/src/Voyager.php
@@ -506,4 +506,9 @@ class Voyager
             return $thumb !== null;
         });
     }
+
+    public function getBreadByName(string $breadName)
+    {
+        return $this->breadmanager->getBreadByName($breadName);
+    }
 }


### PR DESCRIPTION
Similar to Voyager1's `modelClass` method on the `Voyager` facade, this PR adds analogous mechanics to the V2 system. The main purpose of this is to serve as a helper for plugins and such. I'm currently hacking on building a `voyager2-blogs` package and having this functionality seems like it should be very beneficial.

It doesn't change too much in a manner that should be breaking. I've corrected for any issues caused by using string value keys in the Collection. The main concern there was how JS would interpret the collection of breads.

---
# Example
Old code:
```php
    public function authorId()
    {
        return $this->belongsTo(Voyager::modelClass('User'), 'author_id', 'id');
    }
```

New Code:
```php
    public function authorId()
    {
        return $this->belongsTo(Voyager::getBreadByName('User')->model, 'author_id', 'id');
    }
```